### PR TITLE
feature: Auto citate after pull request is accepted

### DIFF
--- a/.github/workflows/gen-citation.yaml
+++ b/.github/workflows/gen-citation.yaml
@@ -1,0 +1,32 @@
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        pip install .[publishing]
+    
+    - name: Generate citation based on pyproject.toml
+      run: |
+        cff-from-621
+    
+    - name: Commit and push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Auto commit after successful merge"
+        git push
+
+      

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,26 @@ target-version = "py37"
 [project]
 name = "pymurtree"
 version = "0.0.1"
+description = "Python bindings for MurTree"
+readme = "README.md"
+license = "MIT"
+keywords = ["MurTree", "Optimal decision tree", "Python bindings"]
+
+authors = [
+  {name = "Yasel Quintero", orcid = "0000-0000-0000-0001"},
+  {name = "Jose Urra", orcid = "0000-0000-0000-0002"},
+]
+
 dependencies =[
     "pandas>=1.0.0",
     "numpy>=1.18.0",
 ]
+
+[project.urls]
+homepage = "https://github.com/MurTree/pymurtree.git"
+MurTreeCpp = "https://github.com/MurTree/murtree"
+sample_data = "https://github.com/MurTree/murtree-data"
+journal = "https://doi.org/10.48550/arXiv.2007.12652"
 
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -25,10 +41,22 @@ dev = [
     "pytest>=5.3.0",
     "pytest-cov>=2.8.0",
 ]
+publishing = [
+    "cff-from-621",
+]
 
 [tool.pytest.ini_options]
 pythonpath = [
   ".", "src/pymurtree",
 ]
 
-[project.urls]
+
+[tool.cff-from-621]
+order = ["message", "cff-version", "title", "abstract", "version", "date-released", "authors", "keywords"]
+
+[tool.cff-from-621.static]
+date-released = "2022-09-18"
+message = "If you use this software, please cite it as below."
+
+[tool.setuptools.dynamic]
+version = {attr = "cff_from_621.version.VERSION"}


### PR DESCRIPTION
With this commit we make sure we can generate citation metadata from pyproject.toml, this allows us to keep both metadata files up to date and use the pyproject.toml as a source of truth